### PR TITLE
Escaped dot in referrer to avoid catching any character

### DIFF
--- a/referrer_spam/nginx-refspam-config-gen.py
+++ b/referrer_spam/nginx-refspam-config-gen.py
@@ -72,7 +72,7 @@ with urllib.request.urlopen(args.input_url) as fi:
         fo.write('\thostnames;\n\n')
         fo.write('\tdefault\t0;\n')
         for l in fi:
-            h = l.decode('utf8').strip()
+            h = l.decode('utf8').strip().replace('.', '\.')
             if args.verbose:
                 print('Writing {0}'.format(h))
             fo.write('\t"~{0}"\t1;\n'.format(h))


### PR DESCRIPTION
Currently the referrer domains are written like:

`````` "~ico.re"```
Since this is a regular expression the dot will match any char. For example "icobre" will be matched as well since dot matches the "b".

When the dot is escaped this works as expected. Test with:
```curl -e "http://good.referrer.co/search?q=picobrew" "http://your.nginx.box.co"
``````
